### PR TITLE
Credentials encoding differences between Environments

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,8 +18,8 @@
     "Bungie"
   ],
   "contributors": [
-    "Francesco Lombardo <frawolf@outlook.it> (https://frawolf.dev)",
-    "Luca Pattocchio <> ()"
+    "Francesco Lombardo <me@frawolf.dev> (https://frawolf.dev)",
+    "Luca Pattocchio <me@lucapattocchio.dev> (https://lucapattocchio.dev)"
   ],
   "license": "MIT",
   "bugs": {

--- a/src/adapters/utils.ts
+++ b/src/adapters/utils.ts
@@ -52,3 +52,7 @@ export function generateOptions(changes: Options): ClientOptions {
     },
   };
 }
+
+export function checkRunningEnvironment() {
+  return typeof process !== "undefined" && process.versions != null && process.versions.node != null ? "node" : "browser";
+}

--- a/src/contents/oauth/index.ts
+++ b/src/contents/oauth/index.ts
@@ -1,4 +1,4 @@
-import { formatQueryStrings, request } from "../../adapters";
+import { checkRunningEnvironment, formatQueryStrings, request } from "../../adapters";
 import { TokenError, TokenResponse } from "../../types";
 
 export class OAuth {
@@ -11,7 +11,8 @@ export class OAuth {
   ) {}
 
   private btoa(data: string) {
-    return Buffer.from(data).toString("base64");
+    if (checkRunningEnvironment() === "node") return Buffer.from(data).toString("base64");
+    else return btoa(data);
   }
 
   private encodeCredentials() {

--- a/src/contents/oauth/index.ts
+++ b/src/contents/oauth/index.ts
@@ -2,6 +2,10 @@ import { checkRunningEnvironment, formatQueryStrings, request } from "../../adap
 import { TokenError, TokenResponse } from "../../types";
 
 export class OAuth {
+  private get environment() {
+    return checkRunningEnvironment();
+  }
+
   constructor(
     private authUrl: string,
     private tokenUrl: string,
@@ -11,8 +15,11 @@ export class OAuth {
   ) {}
 
   private btoa(data: string) {
-    if (checkRunningEnvironment() === "node") return Buffer.from(data).toString("base64");
-    else return btoa(data);
+    if (this.environment === "node") {
+      return Buffer.from(data).toString("base64");
+    } else {
+      return btoa(data);
+    }
   }
 
   private encodeCredentials() {


### PR DESCRIPTION
As title says, I have implemented a different method to calculate and encode credentials for OAuth2 flow. On node.js environment will be used Buffer, and, in the browser-client, will be used btoa() built-in method.

---

This pull request includes several changes to the codebase, primarily focusing on updating contributor information, adding a new utility function, and modifying the OAuth class to check the running environment. Below are the most important changes:

### Contributor Information Update:
* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L21-R22): Updated the email addresses and URLs for contributors Francesco Lombardo and Luca Pattocchio.

### Utility Function Addition:
* [`src/adapters/utils.ts`](diffhunk://#diff-02fca99c85ea26dd9d9587388862390ab0af8c172fbb06f9d6c21085febeb344R59-R62): Added a new function `checkRunningEnvironment` to determine if the code is running in a Node.js environment or a browser environment.

### OAuth Class Enhancements:
* [`src/contents/oauth/index.ts`](diffhunk://#diff-3cea4f93ad4ee1b209e0728a3050f7aadb6ad1aaf64329cffe65dd104d72d3d1L1-R8): Imported the new `checkRunningEnvironment` function and added a private `environment` getter in the `OAuth` class to utilize this function.
* [`src/contents/oauth/index.ts`](diffhunk://#diff-3cea4f93ad4ee1b209e0728a3050f7aadb6ad1aaf64329cffe65dd104d72d3d1R18-R22): Modified the `btoa` method in the `OAuth` class to use `Buffer` for base64 encoding in a Node.js environment and `btoa` in a browser environment.